### PR TITLE
Fix apt-get choking while installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,10 @@ CMD "/bin/bash"
 
 # Database container
 FROM pls_base AS pls_mysql
-RUN apt-get install -y mysql-client mysql-server
+RUN apt-get install -y libreadline4
+RUN apt-get install -y perl
+RUN apt-get install -y mysql-client
+RUN apt-get install -y mysql-server
 COPY ["database/entrypoint.sh", "database/manage.sh", "/usr/src/"]
 RUN ln -s /usr/src/manage.sh /usr/local/bin/manage_uu
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
@@ -75,7 +78,9 @@ RUN \
 
 # Uru runtime
 FROM pls_base AS pls_uru_server
-RUN apt-get install -y curl mysql-client
+RUN apt-get install -y curl
+RUN apt-get install -y perl-modules
+RUN apt-get install -y mysql-client
 COPY --from=pls_uru_builder /opt/plServers /opt/plServers
 COPY ["plasma/entrypoint.sh", "/opt/plServers/"]
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,11 @@ CMD "/bin/bash"
 
 # Database container
 FROM pls_base AS pls_mysql
-RUN apt-get install -y libreadline4
-RUN apt-get install -y perl
-RUN apt-get install -y mysql-client
-RUN apt-get install -y mysql-server
+RUN \
+    apt-get install -y libreadline4 && \
+    apt-get install -y perl && \
+    apt-get install -y mysql-client && \
+    apt-get install -y mysql-server
 COPY ["database/entrypoint.sh", "database/manage.sh", "/usr/src/"]
 RUN ln -s /usr/src/manage.sh /usr/local/bin/manage_uu
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
@@ -78,9 +79,10 @@ RUN \
 
 # Uru runtime
 FROM pls_base AS pls_uru_server
-RUN apt-get install -y curl
-RUN apt-get install -y perl-modules
-RUN apt-get install -y mysql-client
+RUN \
+    apt-get install -y curl && \
+    apt-get install -y perl-modules && \
+    apt-get install -y mysql-client
 COPY --from=pls_uru_builder /opt/plServers /opt/plServers
 COPY ["plasma/entrypoint.sh", "/opt/plServers/"]
 RUN \

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ any password that you need to keep secret.
 
 To manage accounts on your shard, a convenience script is included with the database container
 called `manage_uu`. To use this script, you will need to invoke it inside of the database container.
-To do so, you will need to use the command `docker execute untiluru_db_1 manage_uu`. Without any
+To do so, you will need to use the command `docker exec untiluru-db-1 manage_uu`. Without any
 arguments, a simple list of help will be printed to the console.
 
 To add an account, use `manage_uu addacct [username] [password]`. If you would like to use the


### PR DESCRIPTION
As of this year, several packages are failing to install when running `docker-compose up`. I was able to get the problematic packages to install by breaking up the commands in the Dockerfile. An example of the types of errors previously generated is below:

```
=> => # Err http://archive.debian.org sarge/main libreadline4 4.3-11
 => => #   400 Bad Request [IP: ::ffff:130.89.148.13 80]
 
=> => # Err http://archive.debian.org sarge/main perl-modules 5.8.4-8sarge0
=> => #   400 Bad Request [IP: ::ffff:130.89.148.13 80]
 
#0 124.4 Failed to fetch http://archive.debian.org/debian/pool/main/p/perl/perl_5.8.4-8sarge6_i386.deb  Size mismatch
#0 124.4 Failed to fetch http://archive.debian.org/debian/pool/main/c/curl/libcurl3_7.13.2-2sarge5_i386.deb  Size mismatch
#0 124.4 Failed to fetch http://archive.debian.org/debian/pool/main/c/curl/curl_7.13.2-2sarge5_i386.deb  Size mismatch
```

Additionally, the readme was changed to fix an error in the command used to manage the server.